### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "servicedirectory",
     "name_pretty": "Service Directory",
     "product_documentation": "https://cloud.google.com/service-directory/",
-    "client_documentation": "https://googleapis.dev/python/servicedirectory/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/servicedirectory/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Service Directory
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-service-directory.svg
    :target: https://pypi.org/project/google-cloud-service-directory/
 .. _Cloud Service Directory API: https://cloud.google.com/service-directory
-.. _Client Library Documentation: https://googleapis.dev/python/servicedirectory/latest/
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/servicedirectory/latest/
 .. _Product Documentation:  https://cloud.google.com/service-directory
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.